### PR TITLE
feat: add SQLite ping history logging

### DIFF
--- a/MacThrottle/Services/PingLogger.swift
+++ b/MacThrottle/Services/PingLogger.swift
@@ -1,0 +1,240 @@
+// PingLogger.swift
+// AIDEV-NOTE: SQLite-based ping history logging service
+
+import Foundation
+import SQLite3
+
+/// Singleton service for logging ping results to SQLite database
+final class PingLogger: @unchecked Sendable {
+    static let shared = PingLogger()
+
+    private var db: OpaquePointer?
+    private let queue = DispatchQueue(label: "com.maclatency.pinglogger", qos: .utility)
+
+    /// Default retention period in days
+    static let defaultRetentionDays = 30
+    static let retentionDaysOptions = [7, 14, 30, 60, 90, 180, 365]
+
+    private init() {
+        openDatabase()
+        createTableIfNeeded()
+    }
+
+    deinit {
+        if db != nil {
+            sqlite3_close(db)
+        }
+    }
+
+    // MARK: - Database Setup
+
+    private func getDatabasePath() -> String {
+        let fileManager = FileManager.default
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appFolder = appSupport.appendingPathComponent("MacLatency", isDirectory: true)
+
+        // Create directory if needed
+        try? fileManager.createDirectory(at: appFolder, withIntermediateDirectories: true)
+
+        return appFolder.appendingPathComponent("ping_history.sqlite").path
+    }
+
+    private func openDatabase() {
+        let path = getDatabasePath()
+        if sqlite3_open(path, &db) != SQLITE_OK {
+            print("[PINGLOG-OPEN-ERR] Failed to open database at \(path)")
+            db = nil
+        }
+    }
+
+    private func createTableIfNeeded() {
+        guard db != nil else { return }
+
+        let createSQL = """
+            CREATE TABLE IF NOT EXISTS ping_log (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp REAL NOT NULL,
+                host_id TEXT NOT NULL,
+                host_label TEXT NOT NULL,
+                host_address TEXT NOT NULL,
+                latency_ms REAL,
+                status TEXT NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_ping_log_timestamp ON ping_log(timestamp);
+            CREATE INDEX IF NOT EXISTS idx_ping_log_host_id ON ping_log(host_id);
+        """
+
+        var errMsg: UnsafeMutablePointer<CChar>?
+        if sqlite3_exec(db, createSQL, nil, nil, &errMsg) != SQLITE_OK {
+            if let err = errMsg {
+                print("[PINGLOG-CREATE-ERR] \(String(cString: err))")
+                sqlite3_free(errMsg)
+            }
+        }
+    }
+
+    // MARK: - Logging
+
+    /// Log a batch of readings to the database
+    func logReadings(_ readings: [LatencyReading]) {
+        guard db != nil else { return }
+
+        queue.async { [weak self] in
+            self?.insertReadings(readings)
+        }
+    }
+
+    private func insertReadings(_ readings: [LatencyReading]) {
+        guard db != nil else { return }
+
+        let insertSQL = """
+            INSERT INTO ping_log (timestamp, host_id, host_label, host_address, latency_ms, status)
+            VALUES (?, ?, ?, ?, ?, ?);
+        """
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, insertSQL, -1, &stmt, nil) == SQLITE_OK else {
+            print("[PINGLOG-PREP-ERR] Failed to prepare insert statement")
+            return
+        }
+
+        defer { sqlite3_finalize(stmt) }
+
+        // Use transaction for batch insert
+        sqlite3_exec(db, "BEGIN TRANSACTION", nil, nil, nil)
+
+        for reading in readings {
+            sqlite3_reset(stmt)
+
+            let timestamp = reading.timestamp.timeIntervalSince1970
+            let hostId = reading.hostId.uuidString
+            let hostLabel = reading.hostLabel
+            let hostAddress = reading.hostAddress
+            let status = reading.status.rawValue
+
+            sqlite3_bind_double(stmt, 1, timestamp)
+            sqlite3_bind_text(stmt, 2, hostId, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 3, hostLabel, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+            sqlite3_bind_text(stmt, 4, hostAddress, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+
+            if let latencyMs = reading.latencyMs {
+                sqlite3_bind_double(stmt, 5, latencyMs)
+            } else {
+                sqlite3_bind_null(stmt, 5)
+            }
+
+            sqlite3_bind_text(stmt, 6, status, -1, unsafeBitCast(-1, to: sqlite3_destructor_type.self))
+
+            if sqlite3_step(stmt) != SQLITE_DONE {
+                print("[PINGLOG-INSERT-ERR] Failed to insert reading")
+            }
+        }
+
+        sqlite3_exec(db, "COMMIT", nil, nil, nil)
+    }
+
+    // MARK: - Cleanup
+
+    /// Delete records older than the specified number of days
+    func cleanupOldRecords(olderThanDays days: Int) {
+        guard db != nil else { return }
+
+        queue.async { [weak self] in
+            self?.performCleanup(days: days)
+        }
+    }
+
+    private func performCleanup(days: Int) {
+        guard db != nil else { return }
+
+        let cutoffTimestamp = Date().addingTimeInterval(-Double(days) * 24 * 60 * 60).timeIntervalSince1970
+
+        let deleteSQL = "DELETE FROM ping_log WHERE timestamp < ?;"
+
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, deleteSQL, -1, &stmt, nil) == SQLITE_OK else {
+            print("[PINGLOG-CLEANUP-PREP-ERR] Failed to prepare delete statement")
+            return
+        }
+
+        defer { sqlite3_finalize(stmt) }
+
+        sqlite3_bind_double(stmt, 1, cutoffTimestamp)
+
+        if sqlite3_step(stmt) == SQLITE_DONE {
+            let deletedCount = sqlite3_changes(db)
+            if deletedCount > 0 {
+                print("[PINGLOG-CLEANUP] Deleted \(deletedCount) old records")
+            }
+        }
+
+        // Vacuum periodically to reclaim space
+        sqlite3_exec(db, "VACUUM", nil, nil, nil)
+    }
+
+    // MARK: - Statistics
+
+    /// Get the total number of logged records
+    func getRecordCount() -> Int {
+        guard db != nil else { return 0 }
+
+        var count = 0
+        let sql = "SELECT COUNT(*) FROM ping_log;"
+
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                count = Int(sqlite3_column_int64(stmt, 0))
+            }
+            sqlite3_finalize(stmt)
+        }
+
+        return count
+    }
+
+    /// Get the database file size in bytes
+    func getDatabaseSize() -> Int64 {
+        let path = getDatabasePath()
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attrs[.size] as? Int64 else {
+            return 0
+        }
+        return size
+    }
+
+    /// Get the date range of stored records
+    func getDateRange() -> (oldest: Date?, newest: Date?) {
+        guard db != nil else { return (nil, nil) }
+
+        var oldest: Date?
+        var newest: Date?
+
+        let sql = "SELECT MIN(timestamp), MAX(timestamp) FROM ping_log;"
+
+        var stmt: OpaquePointer?
+        if sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK {
+            if sqlite3_step(stmt) == SQLITE_ROW {
+                if sqlite3_column_type(stmt, 0) != SQLITE_NULL {
+                    oldest = Date(timeIntervalSince1970: sqlite3_column_double(stmt, 0))
+                }
+                if sqlite3_column_type(stmt, 1) != SQLITE_NULL {
+                    newest = Date(timeIntervalSince1970: sqlite3_column_double(stmt, 1))
+                }
+            }
+            sqlite3_finalize(stmt)
+        }
+
+        return (oldest, newest)
+    }
+
+    /// Delete all records
+    func deleteAllRecords() {
+        guard db != nil else { return }
+
+        queue.async { [weak self] in
+            guard let self = self, self.db != nil else { return }
+            sqlite3_exec(self.db, "DELETE FROM ping_log; VACUUM;", nil, nil, nil)
+            print("[PINGLOG-CLEAR] All records deleted")
+        }
+    }
+}

--- a/MacThrottle/Views/MenuContentView.swift
+++ b/MacThrottle/Views/MenuContentView.swift
@@ -10,6 +10,7 @@ struct MenuContentView: View {
     @State private var newHostLabel: String = ""
     @State private var showAddHost: Bool = false
     @State private var showThresholds: Bool = false
+    @State private var showLogging: Bool = false
 
     /// Get color for latency using current thresholds
     private func colorForLatency(_ ms: Double) -> Color {
@@ -129,6 +130,9 @@ struct MenuContentView: View {
 
             // Thresholds section
             thresholdsSection
+
+            // Logging section
+            loggingSection
 
             Divider()
 
@@ -317,6 +321,67 @@ struct MenuContentView: View {
                 .font(.caption2)
                 .foregroundColor(color)
         }
+    }
+
+    @ViewBuilder
+    private var loggingSection: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Button {
+                showLogging.toggle()
+            } label: {
+                HStack {
+                    Text("History Logging")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Image(systemName: showLogging ? "chevron.down" : "chevron.right")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                }
+            }
+            .buttonStyle(.plain)
+
+            if showLogging {
+                VStack(alignment: .leading, spacing: 4) {
+                    Toggle("Enable Logging", isOn: $monitor.loggingEnabled)
+                        .controlSize(.small)
+
+                    HStack {
+                        Text("Retain:")
+                        Spacer()
+                        Picker("", selection: $monitor.logRetentionDays) {
+                            ForEach(PingLogger.retentionDaysOptions, id: \.self) { days in
+                                Text("\(days) days").tag(days)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                        .frame(width: 90)
+                    }
+                    .controlSize(.small)
+
+                    // Show stats
+                    let stats = getLoggingStats()
+                    Text(stats)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+
+                    Button("Clear All Logs") {
+                        PingLogger.shared.deleteAllRecords()
+                    }
+                    .controlSize(.small)
+                    .foregroundColor(.red)
+                }
+                .padding(.leading, 8)
+            }
+        }
+    }
+
+    private func getLoggingStats() -> String {
+        let count = PingLogger.shared.getRecordCount()
+        let size = PingLogger.shared.getDatabaseSize()
+        let sizeStr = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+        return "\(count.formatted()) records (\(sizeStr))"
     }
 
     private func openAboutWindow() {


### PR DESCRIPTION
### **User description**
## Summary

- Add optional (default on) logging of all ping results to a local SQLite database
- Configurable retention period (7-365 days, default 30)
- Shows record count and database size in the UI
- Automatic cleanup of old records (hourly + on startup)

## Details

### PingLogger Service
- Stores readings in `~/Library/Application Support/MacLatency/ping_history.sqlite`
- Uses SQLite3 directly (available on macOS, no dependencies)
- Thread-safe with dedicated dispatch queue for writes

### Database Schema
```sql
ping_log (
    id INTEGER PRIMARY KEY,
    timestamp REAL,
    host_id TEXT,
    host_label TEXT,
    host_address TEXT,
    latency_ms REAL,
    status TEXT
)
```

### UI Controls
- Toggle to enable/disable logging
- Retention period picker (7, 14, 30, 60, 90, 180, 365 days)
- Display of record count and database size
- "Clear All Logs" button

## Test plan
- [ ] Verify logging toggle works
- [ ] Verify retention period changes trigger cleanup
- [ ] Verify database is created in correct location
- [ ] Verify old records are cleaned up after retention period
- [ ] Verify "Clear All Logs" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add SQLite-based ping history logging service with configurable retention

- Integrate logging into LatencyMonitor with automatic hourly cleanup

- Add UI controls for enabling logging and managing retention period

- Display record count and database size in menu interface


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["LatencyMonitor"] -->|"logs readings"| B["PingLogger"]
  B -->|"stores to"| C["SQLite Database"]
  B -->|"cleanup hourly"| C
  D["MenuContentView"] -->|"enable/disable"| A
  D -->|"configure retention"| A
  D -->|"display stats"| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LatencyMonitor.swift</strong><dd><code>Add logging settings and cleanup scheduling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MacThrottle/Services/LatencyMonitor.swift

<ul><li>Add <code>loggingEnabled</code> and <code>logRetentionDays</code> properties with UserDefaults <br>persistence<br> <li> Implement <code>scheduleLogCleanup()</code> to run cleanup on startup and hourly<br> <li> Log readings to SQLite when logging is enabled in the monitoring loop<br> <li> Trigger cleanup when retention period changes</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/maclatency/pull/1/files#diff-5a0b353cdebbca2344f14ef8051f959f396651fe589c5f4e76eb589b66794573">+34/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PingLogger.swift</strong><dd><code>New SQLite ping history logging service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MacThrottle/Services/PingLogger.swift

<ul><li>Create new singleton service for SQLite-based ping history logging<br> <li> Implement database setup with table creation and indexes on timestamp <br>and host_id<br> <li> Add batch insert functionality with transaction support for efficient <br>logging<br> <li> Implement cleanup with configurable retention period and VACUUM <br>optimization<br> <li> Provide statistics methods for record count, database size, and date <br>range<br> <li> Add delete all records functionality for user-initiated clearing</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/maclatency/pull/1/files#diff-ce0f9682d3fb76e1857eafdcbfae1ac99817a1fe0945416fe81822625cc3a790">+240/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MenuContentView.swift</strong><dd><code>Add logging UI section with controls and stats</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

MacThrottle/Views/MenuContentView.swift

<ul><li>Add <code>showLogging</code> state variable to toggle logging section visibility<br> <li> Create collapsible <code>loggingSection</code> with enable/disable toggle<br> <li> Add retention period picker with predefined day options<br> <li> Display logging statistics showing record count and database size<br> <li> Add "Clear All Logs" button with red styling for destructive action</ul>


</details>


  </td>
  <td><a href="https://github.com/jmaddington/maclatency/pull/1/files#diff-9f15125aa16beae3e61e17a4fda50f7ce63654502be70ba53090116ee420e9f2">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

